### PR TITLE
Add option to hide preview images. Fix removing streamer with a preview image

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Twitch Stream Notifier",
-  "version": "1.0",
+  "version": "1.1.1",
   "manifest_version": 2,
   "description": "See when streamers go online!",
   "icons": {

--- a/popup.html
+++ b/popup.html
@@ -81,12 +81,24 @@
                 class="form-check-input"
                 id="hideOffline"
               />
-              <label class="form-check-label" for="exampleCheck1"
+              <label class="form-check-label" for="hideOffline"
                 >Hide offline</label
               >
             </div>
           </div>
-          <div class="col-xs-offset-6 col-xs-3 text-right">
+          <div class="col-xs-6">
+            <div class="form-group form-check">
+              <input
+                type="checkbox"
+                class="form-check-input"
+                id="hidePreviews"
+              />
+              <label class="form-check-label" for="hidePreviews"
+                >Hide previews</label
+              >
+            </div>
+          </div>
+          <div class="col-xs-3 text-right">
             <a href="#" class="text-danger remove-all"
               ><i class="fa fa-times"></i> Remove all</a
             >

--- a/worker/index.js
+++ b/worker/index.js
@@ -36,6 +36,11 @@ const fetchLiveStreamers = async request => {
       streamersToFetch.push(channel);
       return;
     }
+
+    if (streamersCache.offline) {
+      return;
+    }
+
     streamersResponse[channel] = streamersCache.data;
   });
 
@@ -69,6 +74,17 @@ const fetchLiveStreamers = async request => {
         expires: NOW + 60000,
       };
     });
+  });
+
+  streamersToFetch.forEach(streamer => {
+    if (streamersResponse[streamer]) {
+      return;
+    }
+
+    GLOBAL_TWITCH_CACHE[streamer] = {
+      expires: NOW + 60000,
+      offline: true,
+    };
   });
 
   return new Response(JSON.stringify(streamersResponse), RESPONSE_HEADERS);


### PR DESCRIPTION
Version 1.1
- New option to hide preview images
- Efficiently get all storage keys when starting up. 

Version 1.1.1
- Fix removing streamer that was online and image previews were enabled.

Worker changes
- Cache offline streamers for a minute as well