### PR TITLE
Add in worker response for images, swap over to it

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Twitch Stream Notifier",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "manifest_version": 2,
   "description": "See when streamers go online!",
   "icons": {

--- a/scripts/bg_fetch.js
+++ b/scripts/bg_fetch.js
@@ -2,6 +2,7 @@ const knownOnlineStreamers = {};
 const notifications = {};
 const CHANNEL_API_URI = 'https://twitch.theorycraft.gg/channel-status';
 const FOLLOW_API_URI = 'https://twitch.theorycraft.gg/user-follows';
+const PREVIEW_API = 'https://twitch.theorycraft.gg/channel-preview';
 
 const asyncForEach = async (array, callback) => {
   for (let index = 0; index < array.length; index++) {
@@ -72,7 +73,9 @@ const fetchFollows = async (username, callback) => {
 };
 
 const createNotification = async stream => {
-  const imageResponse = await fetch(stream.preview.large);
+  const imageResponse = await fetch(
+    `${PREVIEW_API}/${stream.username}/640/360`
+  );
   const imageData = await imageResponse.blob();
 
   var opt = {
@@ -116,7 +119,9 @@ var pollInterval = 1000 * 60; // 1 minute, in milliseconds
 const poller = async () => {
   chrome.storage.sync.get('twitchStreams', async storage => {
     if (storage.twitchStreams) {
-      await fetchStreamerStatus(storage.twitchStreams, () => {});
+      try {
+        await fetchStreamerStatus(storage.twitchStreams, () => {});
+      } catch (e) {}
     }
     window.setTimeout(poller, pollInterval);
   });

--- a/scripts/pop-up.js
+++ b/scripts/pop-up.js
@@ -1,3 +1,4 @@
+const PREVIEW_API = 'https://twitch.theorycraft.gg/channel-preview';
 let hideOffline = false;
 let hidePreviews = false;
 
@@ -49,7 +50,9 @@ const createStreamerEntry = stream => {
   } else {
     const imageDiv = `
       <div class="col-xs-6">
-        <img class="img-responsive" src="${stream.preview.medium}" />
+        <img class="img-responsive" src="${PREVIEW_API}/${
+      stream.username
+    }/320/180" />
       </div>
     `;
 


### PR DESCRIPTION
1.2.0
- Sometimes the twitch image cdn doesn't set the CORs header so just a new worker response to get around that. 
- Wrap the loop in a try catch so if it throws it won't stop updating. 