### PR TITLE
Fix bug when going from N -> 0 online

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Twitch Stream Notifier",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "manifest_version": 2,
   "description": "See when streamers go online!",
   "icons": {

--- a/scripts/bg_fetch.js
+++ b/scripts/bg_fetch.js
@@ -36,14 +36,20 @@ const fetchStreamerStatus = async (
   });
 
   const numOnline = Object.keys(streamersLive).length;
-  if (numOnline && setBadgeText) {
-    chrome.browserAction.setBadgeText({
-      text: `${numOnline}`,
-    });
+  if (setBadgeText) {
+    if (numOnline > 0) {
+      chrome.browserAction.setBadgeText({
+        text: `${numOnline}`,
+      });
+    } else {
+      chrome.browserAction.setBadgeText({
+        text: '',
+      });
+    }
   }
 
   chrome.browserAction.setTitle({
-    title: `${numOnline} streamers online. ${Object.keys(streamersLive).join(
+    title: `${numOnline} channels online. ${Object.keys(streamersLive).join(
       ', '
     )}`,
   });


### PR DESCRIPTION
1.3.1
- Fix a bug when you had `N` channels online -> `0` online the badge would stay at `N`. 