### PR TITLE
update STREAMS_URI to match helix parameters

### DIFF
--- a/worker/index.js
+++ b/worker/index.js
@@ -1,4 +1,4 @@
-const STREAMS_URI = 'https://api.twitch.tv/helix/streams?offset=0&limit=100';
+const STREAMS_URI = 'https://api.twitch.tv/helix/streams?first=100';
 const USERS_URI = 'https://api.twitch.tv/helix/users';
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION
According to the current [api documentation](https://dev.twitch.tv/docs/api/reference#get-streams) the parameters `offset` and `limit` no longer exist.

From limited testing:
* the api does not support specifying `game_id` **and** `user_login` in the same request (`data` property is empty array)
* the `first` parameter is ignored when using `user_login`, returning a data entry for each streamer that is live
* the returned `pagination` property is an empty object when querying for `user_login`, thus the `after` and `before` parameters are useless unless querying for game IDs
* `user_id` behaves the same as `user_login`, but you can mix them in a single request