### PR TITLE
abbreviateViewerCount based on the numer of viewers

### DIFF
--- a/scripts/pop-up.js
+++ b/scripts/pop-up.js
@@ -4,7 +4,7 @@ let hideOffline = false;
 let hidePreviews = false;
 let hideStreamersOnlineCount = false;
 
-const fetchStreamerStatus = storage => {
+const fetchStreamerStatus = (storage) => {
   if (!storage.twitchStreams) {
     storage.twitchStreams = [];
     chrome.storage.sync.set({ twitchStreams: storage.twitchStreams }, () => {});
@@ -16,7 +16,7 @@ const fetchStreamerStatus = storage => {
         action: 'fetchStreamerStatus',
         usernames: Array.from(new Set(storage.twitchStreams)),
       },
-      response => {
+      (response) => {
         displayStreamerStatus(response);
       }
     );
@@ -25,7 +25,7 @@ const fetchStreamerStatus = storage => {
   }
 };
 
-const updateSetBadgeText = setBadgeText => {
+const updateSetBadgeText = (setBadgeText) => {
   chrome.extension.sendRequest(
     {
       action: 'setBadgeText',
@@ -47,7 +47,16 @@ const sortStreams = (streamA, streamB) => {
   return 0;
 };
 
-const createStreamerEntry = stream => {
+const abbreviateViewerCount = (number) => {
+  // regex to avoid trailing zeros
+  return number >= 1e6
+    ? (number / 1e6).toFixed(1).replace(/\.0$/, '') + 'M'
+    : number >= 1e3
+    ? (number / 1e3).toFixed(1).replace(/\.0$/, '') + 'K'
+    : number;
+};
+
+const createStreamerEntry = (stream) => {
   if (!stream.channel) {
     if (hideOffline) {
       return '';
@@ -85,7 +94,7 @@ const createStreamerEntry = stream => {
             </li>
             <li>
               <i class="fa fa-users"></i>
-              ${stream.viewers}
+              ${abbreviateViewerCount(stream.viewers)}
             </li>
             <li>
               <i class="fa fa-clock-o"></i>
@@ -99,7 +108,7 @@ const createStreamerEntry = stream => {
   }
 };
 
-const displayStreamerStatus = streams => {
+const displayStreamerStatus = (streams) => {
   document.getElementById('loading').classList.add('hidden');
 
   if (!streams) {
@@ -110,7 +119,7 @@ const displayStreamerStatus = streams => {
   document.getElementById('emptyState').classList.add('hidden');
   document.getElementById('streamers').innerHTML = '';
 
-  streams.sort(sortStreams).forEach(stream => {
+  streams.sort(sortStreams).forEach((stream) => {
     const html = createStreamerEntry(stream);
 
     const entry = document.createElement('li');
@@ -128,7 +137,7 @@ document.addEventListener('DOMContentLoaded', () => {
       'hideStreamersOnlineCount',
       'twitchStreams',
     ],
-    storage => {
+    (storage) => {
       hideOffline = storage.hideOffline;
       document.getElementById('hideOffline').checked = !hideOffline;
 
@@ -136,19 +145,18 @@ document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('hidePreviews').checked = !hidePreviews;
 
       hideStreamersOnlineCount = storage.hideStreamersOnlineCount;
-      document.getElementById(
-        'hideStreamersOnlineCount'
-      ).checked = !hideStreamersOnlineCount;
+      document.getElementById('hideStreamersOnlineCount').checked =
+        !hideStreamersOnlineCount;
 
       fetchStreamerStatus(storage);
     }
   );
 
-  document.getElementById('addForm').addEventListener('submit', evt => {
+  document.getElementById('addForm').addEventListener('submit', (evt) => {
     evt.preventDefault();
     const user = document.getElementById('streamerUsername').value;
     if (user) {
-      chrome.storage.sync.get('twitchStreams', storage => {
+      chrome.storage.sync.get('twitchStreams', (storage) => {
         storage.twitchStreams.push(user);
         chrome.storage.sync.set(
           { twitchStreams: Array.from(new Set(storage.twitchStreams)) },
@@ -161,7 +169,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  document.getElementById('syncFollowers').addEventListener('submit', evt => {
+  document.getElementById('syncFollowers').addEventListener('submit', (evt) => {
     evt.preventDefault();
     const user = document.getElementById('username').value;
     if (user) {
@@ -170,7 +178,7 @@ document.addEventListener('DOMContentLoaded', () => {
           action: 'fetchFollows',
           username: user,
         },
-        response => {
+        (response) => {
           displayStreamerStatus(response);
         }
       );
@@ -178,7 +186,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  document.body.addEventListener('click', evt => {
+  document.body.addEventListener('click', (evt) => {
     if (evt.target.nodeName === 'A') {
       if (evt.target.classList.contains('twitch-link')) {
         chrome.tabs.create({ url: evt.target.getAttribute('href') });
@@ -211,7 +219,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const streamer = evt.target.getAttribute('data-username');
 
-      chrome.storage.sync.get('twitchStreams', storage => {
+      chrome.storage.sync.get('twitchStreams', (storage) => {
         const index = storage.twitchStreams.indexOf(streamer);
 
         if (index >= 0) {
@@ -229,14 +237,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  document.getElementById('hideOffline').addEventListener('change', evt => {
+  document.getElementById('hideOffline').addEventListener('change', (evt) => {
     chrome.storage.sync.set({ hideOffline: !evt.target.checked }, () => {
       hideOffline = !evt.target.checked;
       chrome.storage.sync.get('twitchStreams', fetchStreamerStatus);
     });
   });
 
-  document.getElementById('hidePreviews').addEventListener('change', evt => {
+  document.getElementById('hidePreviews').addEventListener('change', (evt) => {
     chrome.storage.sync.set({ hidePreviews: !evt.target.checked }, () => {
       hidePreviews = !evt.target.checked;
       chrome.storage.sync.get('twitchStreams', fetchStreamerStatus);
@@ -245,7 +253,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document
     .getElementById('hideStreamersOnlineCount')
-    .addEventListener('change', evt => {
+    .addEventListener('change', (evt) => {
       chrome.storage.sync.set(
         { hideStreamersOnlineCount: !evt.target.checked },
         () => {


### PR DESCRIPTION
### Description

Twitch's web UI abbreviates the viewer count, I think that looks more readable and consistent.

See images below for more clarity.

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/9327cfc80ea833c97a59b08b4076f930a1308d3d/storage/2022-11-18_14-41-37_pr_abbreviateViewerCount.png" width="800">

---

PS: all these other changes were made by `prettier`.

```zsh
❯ prettier --write scripts/pop-up.js
[warn] jsxBracketSameLine is deprecated.
scripts/pop-up.js 181ms
```

I can revert prettier's changes or do it for all `*.js` files, let me know.
