### PR TITLE
Fix SQLITE_ERROR on channel-status for users tracking >100 channels

### DIFF
--- a/worker/src/twitch_hub.js
+++ b/worker/src/twitch_hub.js
@@ -9,6 +9,10 @@ const TWITCH_BATCH_LIMIT = 100;
 // Workers allow at most 6 simultaneous outbound connections, so cap how many
 // Twitch batches we fetch in parallel.
 const MAX_CONCURRENT_FETCHES = 6;
+// Durable Object SQLite allows at most 100 bound parameters per statement, so
+// chunk IN (...) lookups to stay under the limit for users tracking >100
+// channels.
+const SQL_BIND_LIMIT = 100;
 
 export class TwitchHub extends DurableObject {
   constructor(ctx, env) {
@@ -216,30 +220,32 @@ export class TwitchHub extends DurableObject {
   }
 
   getStoredStatuses(channels) {
-    if (channels.length === 0) {
-      return new Map();
-    }
-
-    const placeholders = channels.map(() => '?').join(', ');
-    const rows = this.ctx.storage.sql
-      .exec(
-        `
-          SELECT channel, is_live, payload, last_synced_at
-          FROM channel_status
-          WHERE channel IN (${placeholders})
-        `,
-        ...channels
-      )
-      .toArray();
-
     const result = new Map();
 
-    for (const row of rows) {
-      result.set(row.channel, {
-        isLive: row.is_live === 1,
-        payload: row.payload ? JSON.parse(row.payload) : null,
-        lastSyncedAt: row.last_synced_at,
-      });
+    // SQLite caps bound parameters at 100 per statement, so chunk the IN (...)
+    // lookup. Without this, status reads for users tracking >100 channels throw
+    // SQLITE_ERROR ("too many SQL variables").
+    for (let index = 0; index < channels.length; index += SQL_BIND_LIMIT) {
+      const chunk = channels.slice(index, index + SQL_BIND_LIMIT);
+      const placeholders = chunk.map(() => '?').join(', ');
+      const rows = this.ctx.storage.sql
+        .exec(
+          `
+            SELECT channel, is_live, payload, last_synced_at
+            FROM channel_status
+            WHERE channel IN (${placeholders})
+          `,
+          ...chunk
+        )
+        .toArray();
+
+      for (const row of rows) {
+        result.set(row.channel, {
+          isLive: row.is_live === 1,
+          payload: row.payload ? JSON.parse(row.payload) : null,
+          lastSyncedAt: row.last_synced_at,
+        });
+      }
     }
 
     return result;


### PR DESCRIPTION
## Problem

`/channel-status` returned 500s in production after the realtime rollout. Live logs and a direct repro confirmed the cause:

```
too many SQL variables at offset 418: SQLITE_ERROR
  at async handleChannelStatus
```

`getStoredStatuses` built a single `IN (...)` with one bound parameter per channel, but Durable Object SQLite caps bound parameters at **100**. Any user following >100 channels hit the error and got a 500 with no statuses. All three call sites (polling `/channel-status`, WebSocket subscribe, cron sync) funnel through `getStoredStatuses`, so the realtime path was affected too.

## Fix

Chunk the `IN (...)` lookup into batches of <=100 and merge results, mirroring the existing `TWITCH_BATCH_LIMIT` chunking on the Twitch fetch side.

## Validation (production)

| Channels | Before | After |
|---|---|---|
| 100 | 200 | 200 |
| 101 | 500 | 200 |
| 150 | 500 | 200 |
| 300 | 500 | 200 |

Real-channel correctness confirmed (live payloads reassemble correctly across batches). Already deployed as version `42faabdf`.