### PR TITLE
Await async handlers in fetch so the catch returns a graceful 500

### DIFF
--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -26,7 +26,10 @@ export default {
 
     try {
       if (url.pathname === '/ws') {
-        return getHubStub(env).fetch(request);
+        // Await async handlers so their rejections route through the catch
+        // below and return a graceful 500 instead of escaping as an uncaught
+        // exception (a `return <promise>` inside try/catch is not caught).
+        return await getHubStub(env).fetch(request);
       }
 
       if (request.method === 'GET' && url.pathname === '/feature-flags') {
@@ -34,7 +37,7 @@ export default {
       }
 
       if (request.method === 'POST' && url.pathname === '/channel-status') {
-        return handleChannelStatus(request, env);
+        return await handleChannelStatus(request, env);
       }
 
       if (
@@ -48,7 +51,7 @@ export default {
         request.method === 'GET' &&
         url.pathname.startsWith('/channel-preview')
       ) {
-        return handlePreviewImage(url);
+        return await handlePreviewImage(url);
       }
 
       if (request.method === 'GET' && url.pathname.startsWith('/version')) {


### PR DESCRIPTION
## Problem

The request router returned async handlers (`/ws`, `/channel-status`, `/channel-preview`) without awaiting them. A `return <promise>` inside a try/catch does not route async rejections through the catch, so failures escaped as uncaught exceptions (Cloudflare 1101) instead of the intended graceful JSON 500. This is why the SQLite bug surfaced as a raw 1101, and it mirrors the uncaught-exception errors on the old token-thrash path (un-awaited handler + `res.json()` throw on a rate-limited token endpoint).

## Fix

`return await` the three async branches so the catch actually wraps them. The remaining branches return a `Response` synchronously and need no await.

## Validation (production, version 44856eb2)

- Malformed JSON body to `/channel-status` -> **graceful `{"error":true,...}` 500** (previously an uncaught 1101).
- 1 / 101 / 300 channels -> 200; real-channel payloads correct.