### PR TITLE
Reject malformed Twitch logins (backend + extension)

### DIFF
--- a/extension/scripts/background.js
+++ b/extension/scripts/background.js
@@ -16,6 +16,12 @@ let transportMode = 'polling';
 let featureFlagRequest = null;
 let featureFlagCache = null;
 
+// Twitch login names are 1-25 chars of lowercase alphanumerics + underscore.
+// Drop anything else so a malformed stored value can't 400 the backend batch.
+const TWITCH_LOGIN = /^[a-z0-9_]{1,25}$/;
+const isValidTwitchLogin = (value) =>
+  typeof value === 'string' && TWITCH_LOGIN.test(value.trim().toLowerCase());
+
 const getPreviewUrl = (userName, width, height) =>
   `https://static-cdn.jtvnw.net/previews-ttv/live_user_${userName}-${width}x${height}.jpg`;
 
@@ -118,10 +124,15 @@ const handleStreamerUpdate = async (type, channel, streamData) => {
 
 const getTrackedUsernames = async () => {
   const storage = await chrome.storage.sync.get('twitchStreams');
+  const stored = storage.twitchStreams || [];
+  const valid = stored.filter(isValidTwitchLogin);
 
-  return Array.from(
-    new Set((storage.twitchStreams || []).map((stream) => stream.toLowerCase()))
-  );
+  // Self-heal: persist the cleaned list if any malformed values were dropped.
+  if (valid.length !== stored.length) {
+    await chrome.storage.sync.set({ twitchStreams: valid });
+  }
+
+  return Array.from(new Set(valid.map((stream) => stream.trim().toLowerCase())));
 };
 
 const fetchStreamerStatus = async (

--- a/extension/scripts/pop-up.js
+++ b/extension/scripts/pop-up.js
@@ -11,6 +11,13 @@ const escapeHtml = (unsafe) => {
 const getPreviewUrl = (userName, width, height) =>
   `https://static-cdn.jtvnw.net/previews-ttv/live_user_${userName}-${width}x${height}.jpg`;
 
+// Twitch login names are 1-25 chars of lowercase alphanumerics + underscore.
+// Anything else makes the backend's Helix batch 400, so reject it on add and
+// strip it from stored data on load.
+const TWITCH_LOGIN = /^[a-z0-9_]{1,25}$/;
+const isValidTwitchLogin = (value) =>
+  typeof value === 'string' && TWITCH_LOGIN.test(value.trim().toLowerCase());
+
 let hideOffline = false;
 let hidePreviews = false;
 let hideStreamersOnlineCount = false;
@@ -19,6 +26,14 @@ const fetchStreamerStatus = (storage) => {
   if (!storage.twitchStreams) {
     storage.twitchStreams = [];
     chrome.storage.sync.set({ twitchStreams: storage.twitchStreams }, () => {});
+  }
+
+  // Auto-remove any stored values Twitch would reject, persisting the cleaned
+  // list so bad entries self-heal on the next load instead of lingering.
+  const validStreams = storage.twitchStreams.filter(isValidTwitchLogin);
+  if (validStreams.length !== storage.twitchStreams.length) {
+    storage.twitchStreams = validStreams;
+    chrome.storage.sync.set({ twitchStreams: validStreams }, () => {});
   }
 
   if (storage.twitchStreams.length) {
@@ -172,21 +187,42 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   );
 
+  const usernameInput = document.getElementById('streamerUsername');
+
+  // Clear the rejection bubble once the user starts fixing the value.
+  usernameInput.addEventListener('input', () => {
+    usernameInput.setCustomValidity('');
+  });
+
   document.getElementById('addForm').addEventListener('submit', (evt) => {
     evt.preventDefault();
-    const user = document.getElementById('streamerUsername').value;
-    if (user) {
-      chrome.storage.sync.get('twitchStreams', (storage) => {
-        storage.twitchStreams.push(user);
-        chrome.storage.sync.set(
-          { twitchStreams: Array.from(new Set(storage.twitchStreams)) },
-          () => {
-            fetchStreamerStatus(storage);
-            document.getElementById('streamerUsername').value = '';
-          }
-        );
-      });
+    const user = usernameInput.value.trim();
+
+    if (!user) {
+      return;
     }
+
+    // Block bad values at the source so they never reach storage or the backend.
+    if (!isValidTwitchLogin(user)) {
+      usernameInput.setCustomValidity(
+        'Enter a valid Twitch username: letters, numbers, or underscore (max 25).'
+      );
+      usernameInput.reportValidity();
+      return;
+    }
+
+    usernameInput.setCustomValidity('');
+
+    chrome.storage.sync.get('twitchStreams', (storage) => {
+      storage.twitchStreams.push(user);
+      chrome.storage.sync.set(
+        { twitchStreams: Array.from(new Set(storage.twitchStreams)) },
+        () => {
+          fetchStreamerStatus(storage);
+          usernameInput.value = '';
+        }
+      );
+    });
   });
 
   document.body.addEventListener('click', (evt) => {

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -4,6 +4,9 @@ export { TwitchHub };
 
 const HUB_NAME = 'global';
 const VERSION = '3.2.0';
+// Twitch login names are 1-25 chars of lowercase alphanumerics + underscore.
+// Drop anything else so one malformed value can't 400 a whole Helix batch.
+const TWITCH_LOGIN = /^[a-z0-9_]{1,25}$/;
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, HEAD, POST, OPTIONS',
@@ -199,7 +202,7 @@ function normalizeChannels(channels) {
       channels
         .filter((channel) => typeof channel === 'string')
         .map((channel) => channel.trim().toLowerCase())
-        .filter(Boolean)
+        .filter((channel) => TWITCH_LOGIN.test(channel))
     )
   );
 }

--- a/worker/src/twitch_hub.js
+++ b/worker/src/twitch_hub.js
@@ -22,6 +22,11 @@ const MAX_FETCH_RETRIES = 2;
 const BASE_BACKOFF_MS = 200;
 const MAX_BACKOFF_MS = 2000;
 const MAX_RETRY_AFTER_MS = 3000;
+// Twitch login names are 1-25 chars of lowercase alphanumerics + underscore. A
+// single malformed value makes Helix reject the entire batch with a generic
+// 400 (it never says which one), so drop anything that can't be a real login
+// before it poisons a batch.
+const TWITCH_LOGIN = /^[a-z0-9_]{1,25}$/;
 
 export class TwitchHub extends DurableObject {
   constructor(ctx, env) {
@@ -558,7 +563,7 @@ function normalizeChannels(channels) {
       channels
         .filter((channel) => typeof channel === 'string')
         .map((channel) => channel.trim().toLowerCase())
-        .filter(Boolean)
+        .filter((channel) => TWITCH_LOGIN.test(channel))
     )
   );
 }


### PR DESCRIPTION
## What

A single malformed `user_login` makes Helix 400 the **entire** batch with a generic message that never names the offender — silently dropping up to 99 valid channels for that tick. Well-formed-but-nonexistent logins never 400, so validating format up front (`^[a-z0-9_]{1,25}$`) eliminates these without bisection or extra API calls.

## Backend
`normalizeChannels` in both the worker entry and the Durable Object now drops anything that can't be a real Twitch login.

## Extension
- **Stop bad adds:** popup add-form rejects invalid usernames via `reportValidity()` before they reach storage or the backend.
- **Auto-clean on load:** popup load (`fetchStreamerStatus`) and the service worker (`getTrackedUsernames`) strip invalid stored values and persist the cleaned list, so pre-existing bad entries self-heal on next load.

## Validation
- Backend (prod, version 9ffed20f): mixed valid+malformed payload returns the valid channel with 200; all-malformed returns `{}`/200 (batch no longer poisoned).
- Regex: 12/12 cases (rejects spaces, dashes, unicode, empty, >25 chars; accepts underscores and mixed case via lowercasing).
- FE: `node --check` passes on both scripts.