### PR TITLE
Drop unneeded host_permissions and background permission

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Twitch Stream Notifier",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "manifest_version": 3,
   "description": "See when streamers go online!",
   "icons": {
@@ -13,11 +13,7 @@
   "background": {
     "service_worker": "scripts/background.js"
   },
-  "permissions": ["notifications", "storage", "background", "alarms"],
-  "host_permissions": [
-    "https://twitch.theorycraft.gg/*",
-    "https://static-cdn.jtvnw.net/*"
-  ],
+  "permissions": ["notifications", "storage", "alarms"],
   "action": {
     "default_icon": "images/logo_128.png",
     "default_title": "Twitch Stream Notifier",


### PR DESCRIPTION
## What

Removes `host_permissions` entirely and the `background` permission from the extension manifest; bumps to 2.4.0.

## Why

- Both hosts the extension talks to return `Access-Control-Allow-Origin: *`:
  - `twitch.theorycraft.gg` — the worker sets CORS headers on every response.
  - `static-cdn.jtvnw.net` — verified the CDN returns `ACAO: *`, including the notification `fetch().blob()` path.
- Under MV3, a service worker's `fetch()` is allowed cross-origin without `host_permissions`; the permission only exists to bypass CORS. Since CORS is satisfied, neither host grant is needed. The WebSocket (`wss://…/ws`) never needed it either.
- `background` is unnecessary for the event-driven worker (alarms + messages).

## Impact

- Clears the "Read and change your data on …" install/store warning with no functional change.
- Removing permissions won't trigger a re-permission prompt for existing users.
- Tested locally: notifications fire and popup previews load.