### PR TITLE
Add cron and WebSocket lifecycle logging for realtime rollout

### DIFF
--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -82,11 +82,23 @@ export default {
 
   async scheduled(controller, env, ctx) {
     const stub = getHubStub(env);
+    // Log the per-tick outcome so the realtime cron is observable during the
+    // rollout: active sessions, channels synced (≈ Twitch req/min), live count,
+    // failed batches, and whether the tick was a no-op (no sessions connected).
     ctx.waitUntil(
-      stub.syncTrackedChannels({
-        cron: controller.cron,
-        scheduledTime: controller.scheduledTime,
-      })
+      stub
+        .syncTrackedChannels({
+          cron: controller.cron,
+          scheduledTime: controller.scheduledTime,
+        })
+        .then((result) => {
+          console.log('cron_sync', result);
+        })
+        .catch((error) => {
+          console.error('cron_sync_error', {
+            message: error instanceof Error ? error.message : String(error),
+          });
+        })
     );
   },
 };

--- a/worker/src/twitch_hub.js
+++ b/worker/src/twitch_hub.js
@@ -57,6 +57,8 @@ export class TwitchHub extends DurableObject {
     server.serializeAttachment({ channels: [] });
     this.sessions.set(server, new Set());
 
+    console.log('ws_connect', { sessions: this.sessions.size });
+
     return new Response(null, {
       status: 101,
       webSocket: client,
@@ -105,9 +107,11 @@ export class TwitchHub extends DurableObject {
     // shared Twitch rate budget. Polling clients refresh their own stale
     // statuses on demand via getChannelStatus().
     const activeSessionChannels = this.getSessionChannels();
+    const sessions = this.sessions.size;
 
     if (activeSessionChannels.length === 0) {
       return {
+        sessions,
         channelsSynced: 0,
         liveChannels: 0,
         skipped: true,
@@ -120,6 +124,7 @@ export class TwitchHub extends DurableObject {
     const result = await this.syncChannels(activeSessionChannels);
 
     return {
+      sessions,
       ...result,
       metadata,
     };
@@ -145,6 +150,11 @@ export class TwitchHub extends DurableObject {
     this.sessions.set(ws, new Set(channels));
     ws.serializeAttachment({ channels });
 
+    console.log('ws_subscribe', {
+      channels: channels.length,
+      sessions: this.sessions.size,
+    });
+
     await this.trackChannels(channels);
 
     const currentState = this.buildResponse(
@@ -165,10 +175,12 @@ export class TwitchHub extends DurableObject {
 
   async webSocketClose(ws) {
     this.sessions.delete(ws);
+    console.log('ws_close', { sessions: this.sessions.size });
   }
 
   async webSocketError(ws) {
     this.sessions.delete(ws);
+    console.log('ws_error', { sessions: this.sessions.size });
   }
 
   initializeSchema() {
@@ -538,6 +550,7 @@ export class TwitchHub extends DurableObject {
 
   broadcast(channel, message) {
     const payload = JSON.stringify(message);
+    let recipients = 0;
 
     for (const [ws, subscribedChannels] of this.sessions.entries()) {
       if (!subscribedChannels.has(channel)) {
@@ -546,6 +559,7 @@ export class TwitchHub extends DurableObject {
 
       try {
         ws.send(payload);
+        recipients += 1;
       } catch (error) {
         this.sessions.delete(ws);
         console.warn('websocket_send_failed', {
@@ -554,6 +568,14 @@ export class TwitchHub extends DurableObject {
         });
       }
     }
+
+    // Confirms LIVE/OFFLINE transitions are actually delivered. recipients: 0
+    // means the transition fired but no connected session was subscribed.
+    console.log('ws_broadcast', {
+      type: message.type,
+      channel,
+      recipients,
+    });
   }
 }
 


### PR DESCRIPTION
## Why

Make the realtime code path observable before ramping `REALTIME_ROLLOUT_PERCENT`. The extension silently falls back to polling on any WebSocket failure (good for users), which means a broken realtime cohort is **indistinguishable from a healthy one** from the server side. These logs let us watch the cron and socket path as we ramp.

## What

**Cron outcome (`index.js`)**
- `scheduled()` now awaits `syncTrackedChannels` and logs `cron_sync` per tick — data it already computed and discarded: `sessions`, `channelsSynced` (≈ Twitch req/min), `liveChannels`, `failedChannels`, `skipped`.
- Added a `cron_sync_error` catch so a throwing tick can't vanish silently.
- `syncTrackedChannels()` now includes the active session count in its result.

**WebSocket lifecycle (`twitch_hub.js`)**
- `ws_connect` / `ws_subscribe` / `ws_close` / `ws_error` — each with the live session count; subscribe also logs channel count.
- `broadcast()` counts recipients and logs `ws_broadcast { type, channel, recipients }` — confirms LIVE/OFFLINE transitions actually reach sockets.

## Verification

Deployed and tailed production, then drove a real WebSocket (connect → subscribe to 6 channels → close) across a cron tick. Confirmed every log type fired with correct payloads:
- `cron_sync { sessions: 0, channelsSynced: 0, liveChannels: 0, skipped: true, metadata: {...} }`
- `ws_connect { sessions }`, `ws_subscribe { channels: 6, sessions: 1 }`, `ws_close { sessions }`
- `ws_broadcast { type, channel, recipients }`

Note: `ws_broadcast` also fires on the polling path (`/channel-status → syncChannels → broadcast`) with `recipients: 0` when no socket is subscribed — that's expected transition-detection signal; `recipients > 0` is the realtime-delivery number.