### PR TITLE
Fix chronic Helix 400 from leading-underscore logins

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Twitch Stream Notifier",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "manifest_version": 3,
   "description": "See when streamers go online!",
   "icons": {

--- a/extension/scripts/background.js
+++ b/extension/scripts/background.js
@@ -20,9 +20,11 @@ let reconnectAttempts = 0;
 // anything that went live while the socket was down.
 let pendingSnapshotNotify = false;
 
-// Twitch login names are 1-25 chars of lowercase alphanumerics + underscore.
-// Drop anything else so a malformed stored value can't 400 the backend batch.
-const TWITCH_LOGIN = /^[a-z0-9_]{1,25}$/;
+// Twitch login names are 1-25 chars of lowercase alphanumerics + underscore and
+// must NOT begin with an underscore. Drop anything else so a malformed stored
+// value can't 400 the backend batch. Keep in sync with the worker's
+// TWITCH_LOGIN (worker/src/twitch_hub.js).
+const TWITCH_LOGIN = /^[a-z0-9][a-z0-9_]{0,24}$/;
 const isValidTwitchLogin = (value) =>
   typeof value === 'string' && TWITCH_LOGIN.test(value.trim().toLowerCase());
 

--- a/extension/scripts/pop-up.js
+++ b/extension/scripts/pop-up.js
@@ -11,10 +11,11 @@ const escapeHtml = (unsafe) => {
 const getPreviewUrl = (userName, width, height) =>
   `https://static-cdn.jtvnw.net/previews-ttv/live_user_${userName}-${width}x${height}.jpg`;
 
-// Twitch login names are 1-25 chars of lowercase alphanumerics + underscore.
-// Anything else makes the backend's Helix batch 400, so reject it on add and
-// strip it from stored data on load.
-const TWITCH_LOGIN = /^[a-z0-9_]{1,25}$/;
+// Twitch login names are 1-25 chars of lowercase alphanumerics + underscore and
+// must NOT begin with an underscore. Anything else makes the backend's Helix
+// batch 400, so reject it on add and strip it from stored data on load. Keep in
+// sync with the worker's TWITCH_LOGIN (worker/src/twitch_hub.js).
+const TWITCH_LOGIN = /^[a-z0-9][a-z0-9_]{0,24}$/;
 const isValidTwitchLogin = (value) =>
   typeof value === 'string' && TWITCH_LOGIN.test(value.trim().toLowerCase());
 

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,12 +1,9 @@
-import { TwitchHub } from './twitch_hub.js';
+import { TwitchHub, normalizeChannels } from './twitch_hub.js';
 
 export { TwitchHub };
 
 const HUB_NAME = 'global';
 const VERSION = '3.4.0';
-// Twitch login names are 1-25 chars of lowercase alphanumerics + underscore.
-// Drop anything else so one malformed value can't 400 a whole Helix batch.
-const TWITCH_LOGIN = /^[a-z0-9_]{1,25}$/;
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, HEAD, POST, OPTIONS',
@@ -183,15 +180,4 @@ function jsonResponse(data, init = {}) {
 
 function getHubStub(env) {
   return env.TWITCH_HUB.getByName(HUB_NAME);
-}
-
-function normalizeChannels(channels) {
-  return Array.from(
-    new Set(
-      channels
-        .filter((channel) => typeof channel === 'string')
-        .map((channel) => channel.trim().toLowerCase())
-        .filter((channel) => TWITCH_LOGIN.test(channel))
-    )
-  );
 }

--- a/worker/src/twitch_hub.js
+++ b/worker/src/twitch_hub.js
@@ -22,11 +22,16 @@ const MAX_FETCH_RETRIES = 2;
 const BASE_BACKOFF_MS = 200;
 const MAX_BACKOFF_MS = 2000;
 const MAX_RETRY_AFTER_MS = 3000;
-// Twitch login names are 1-25 chars of lowercase alphanumerics + underscore. A
-// single malformed value makes Helix reject the entire batch with a generic
-// 400 (it never says which one), so drop anything that can't be a real login
-// before it poisons a batch.
-const TWITCH_LOGIN = /^[a-z0-9_]{1,25}$/;
+// Twitch login names are 1-25 chars of lowercase alphanumerics + underscore but
+// must NOT begin with an underscore. A single malformed value makes Helix reject
+// the entire batch with a generic 400 "Malformed query params." (it never says
+// which one), so drop anything that can't be a real login before it poisons a
+// batch. The earlier /^[a-z0-9_]{1,25}$/ let leading-underscore values through
+// (e.g. "___", "_test", "_gocchan_"), which Twitch rejects — confirmed in prod
+// logs as the source of the persistent 400s. Length stays permissive (1+) so
+// legacy short accounts aren't silently dropped; only the leading underscore,
+// the proven offender, is excluded.
+const TWITCH_LOGIN = /^[a-z0-9][a-z0-9_]{0,24}$/;
 
 export class TwitchHub extends DurableObject {
   constructor(ctx, env) {
@@ -602,9 +607,29 @@ export class TwitchHub extends DurableObject {
       });
 
       if (!response.ok) {
+        // Helix returns a JSON body describing the exact failure (e.g.
+        // {"error":"Bad Request","status":400,"message":"Malformed query
+        // parameter \"user_login\"..."}). Surface it — plus the batch shape and
+        // a channel sample — so a 400 can be traced to the offending input. Read
+        // defensively: the body may be empty or non-JSON, and parsing must never
+        // mask the original failure.
+        let body = null;
+        try {
+          // Helix error bodies are tiny; the generous cap only trims a
+          // pathological upstream error page, never a real Twitch message.
+          body = (await response.text()).slice(0, 2000);
+        } catch {
+          body = '<unreadable>';
+        }
+        // Log the full batch (capped at TWITCH_BATCH_LIMIT = 100) rather than a
+        // sample: a 400 is usually one offending login, which could sit anywhere
+        // in the batch. This is an error-only path, so verbosity is cheap.
         console.error('twitch_fetch_failed', {
           status: response.status,
           statusText: response.statusText,
+          body,
+          batchSize: channels.length,
+          channels,
         });
         // A revoked/invalidated token keeps failing until it expires; drop it
         // so the next sync fetches a fresh one.
@@ -620,6 +645,8 @@ export class TwitchHub extends DurableObject {
     } catch (error) {
       console.error('twitch_fetch_error', {
         message: error instanceof Error ? error.message : String(error),
+        batchSize: channels.length,
+        channels,
       });
       return null;
     }
@@ -806,6 +833,11 @@ async function fetchWithRetry(url, options = {}, retries = MAX_FETCH_RETRIES) {
 }
 
 function isRetryableStatus(status) {
+  // Only rate-limits and server errors are transient. We do NOT retry 400:
+  // Helix's 400 "Malformed query params." is deterministic on batch content (an
+  // invalid login such as a leading-underscore name poisons the whole batch),
+  // so retrying just triples the call count and still fails. The fix is to keep
+  // bad logins out of the batch (see TWITCH_LOGIN), not to retry.
   return status === 429 || status >= 500;
 }
 

--- a/worker/src/twitch_hub.js
+++ b/worker/src/twitch_hub.js
@@ -773,7 +773,10 @@ export class TwitchHub extends DurableObject {
   }
 }
 
-function normalizeChannels(channels) {
+// Exported so index.js's /channel-status handler validates with the exact same
+// rules — keeping a single source of truth for TWITCH_LOGIN avoids the two
+// copies drifting and letting bad logins reach the DO.
+export function normalizeChannels(channels) {
   return Array.from(
     new Set(
       channels


### PR DESCRIPTION
## Problem

Helix `/streams` was throwing a chronic 400 `Malformed query params.` — ~16/hr over the last 24h (379 occurrences), the large majority on full 100-channel batches. A 400 nulls the **entire** batch, so 99 good channels go stale on each hit.

## Root cause (confirmed in prod logs)

The error-path logging added here surfaced the offending input. The `batchSize=1` failures isolated the culprits:

```
___        _test        _gocchan_
```

All start with an underscore. The `TWITCH_LOGIN` validator (`/^[a-z0-9_]{1,25}$/`) allowed leading underscores, but Twitch rejects such logins — and one bad value poisons the whole batch.

This also disproves the "400 is flaky, retry it" theory: every logged failure had already exhausted its retries, i.e. the failure is **deterministic on batch content**, not transient.

## Changes

- **Tighten `TWITCH_LOGIN`** to `/^[a-z0-9][a-z0-9_]{0,24}$/` — forbids leading underscore so bad logins are dropped in `normalizeChannels` before they reach Helix. Length stays permissive (1+) so legacy short accounts aren't silently dropped.
- **Add error-path logging** (`body`/`status`/`batchSize`/`channels`) to `fetchLiveBatch` so a 400 is traceable to the offending input.
- **Stop retrying 400s** — deterministic on batch content, so retrying just triples Helix calls and still fails.

## Verification

The validator fix was deployed (version `88dbecb6`) ahead of this PR. Post-deploy: **zero** `twitch_fetch_failed` 400s, versus ~16/hr before.

> Note: the deployed `88dbecb6` still contains the 400-retry; this PR reverts it. A redeploy after merge brings prod fully in line with this branch.
